### PR TITLE
Add APScheduler ingestion with tests

### DIFF
--- a/app/events.py
+++ b/app/events.py
@@ -1,0 +1,4 @@
+import asyncio
+
+# Queue for server-sent events
+event_queue: asyncio.Queue = asyncio.Queue()

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from .database import SessionLocal, engine
 from . import models, schemas
 from .services import fetch_neos, store_neos
 from .scheduler import scheduler
+from .events import event_queue
 from datetime import datetime, date
 import json
 
@@ -100,8 +101,6 @@ async def delete_subscriber(sub_id: int, db: Session = Depends(get_db)):
     db.delete(sub)
     db.commit()
     return Response(status_code=204)
-
-event_queue: asyncio.Queue = asyncio.Queue()
 
 @app.get("/stream/neos")
 async def stream_neos(request: Request):

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -1,15 +1,23 @@
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
 from datetime import datetime
 from .database import SessionLocal
 from .services import fetch_neos, store_neos
+from . import schemas
+from .events import event_queue
 
 scheduler = AsyncIOScheduler()
 
-@scheduler.scheduled_job('cron', hour=0)
-async def daily_ingest():
+async def ingest_once():
     db = SessionLocal()
     try:
         neos = fetch_neos(datetime.utcnow())
-        store_neos(db, neos)
+        stored = store_neos(db, neos)
+        for n in stored:
+            event_queue.put_nowait(schemas.NeoRead.from_orm(n).dict())
     finally:
         db.close()
+
+@scheduler.scheduled_job(IntervalTrigger(hours=1))
+async def scheduled_ingest():
+    await ingest_once()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,8 @@ import os
 os.environ['TEST_DB_URL'] = 'sqlite:///test.db'
 import pytest
 from httpx import AsyncClient
-from app.main import app, scheduler, event_queue
+from app.main import app, scheduler
+from app.events import event_queue
 from app import models
 from app.database import engine
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,7 @@ from datetime import date
 
 from app import services, models
 from app.database import SessionLocal, engine
-from app.main import event_queue
+from app.events import event_queue
 
 models.Base.metadata.create_all(bind=engine)
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,50 @@
+import asyncio
+from datetime import datetime, date
+
+import pytest
+
+from apscheduler.triggers.interval import IntervalTrigger
+
+from app import services, models
+from app.database import engine
+from app.scheduler import scheduler, ingest_once
+from app.events import event_queue
+
+
+@pytest.mark.asyncio
+async def test_scheduler_config():
+    jobs = scheduler.get_jobs()
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert isinstance(job.trigger, IntervalTrigger)
+    assert job.trigger.interval.total_seconds() == 3600
+
+
+@pytest.mark.asyncio
+async def test_scheduler_runs(monkeypatch):
+    models.Base.metadata.drop_all(bind=engine)
+    models.Base.metadata.create_all(bind=engine)
+    while not event_queue.empty():
+        event_queue.get_nowait()
+
+    def fake_fetch(_):
+        return [{
+            "neo_id": "99",
+            "name": "Sched",
+            "close_approach_date": date.today(),
+            "diameter_km": 1.0,
+            "velocity_km_s": 1.0,
+            "miss_distance_au": 0.04,
+            "hazardous": True,
+        }]
+
+    monkeypatch.setattr(services, "fetch_neos", fake_fetch)
+    monkeypatch.setattr(services.slack_session, "post", lambda *a, **k: None)
+
+    scheduler.remove_all_jobs()
+    scheduler.add_job(ingest_once, IntervalTrigger(seconds=0.1), next_run_time=datetime.utcnow())
+    scheduler.start()
+    await asyncio.sleep(0.2)
+    scheduler.shutdown(wait=False)
+
+    assert not event_queue.empty()


### PR DESCRIPTION
## Summary
- schedule hourly NEO ingestion and broadcast events
- share event queue via new `events` module
- adjust startup wiring
- add scheduler tests and updates

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_b_68727636fc30832f8745857141249fb2