### PR TITLE
Implement NEO services and tests

### DIFF
--- a/app/services.py
+++ b/app/services.py
@@ -1,9 +1,13 @@
+import os
+import time
+import httpx
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 from datetime import datetime
 from sqlalchemy.orm import Session
-from .config import NASA_API_KEY, SLACK_WEBHOOK_URL
+from typing import List
+from .config import NASA_API_KEY
 from . import models
 
 API_URL = "https://api.nasa.gov/neo/rest/v1/feed"
@@ -13,33 +17,45 @@ slack_session = requests.Session()
 retries = Retry(total=3, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
 slack_session.mount("https://", HTTPAdapter(max_retries=retries))
 
-def fetch_neos(date: datetime):
+def fetch_neos(date: datetime) -> List[dict]:
+    """Fetch NEO data for a single day from NASA."""
+
+    date_str = date.strftime("%Y-%m-%d")
     params = {
-        "start_date": date.strftime("%Y-%m-%d"),
-        "end_date": date.strftime("%Y-%m-%d"),
-        "api_key": NASA_API_KEY,
+        "start_date": date_str,
+        "end_date": date_str,
+        "api_key": os.getenv("NASA_API_KEY", NASA_API_KEY),
     }
-    resp = requests.get(API_URL, params=params, timeout=10)
+
+    resp = httpx.get(API_URL, params=params, timeout=10)
     resp.raise_for_status()
     data = resp.json()
-    neos = []
-    for item in data.get("near_earth_objects", {}).get(params["start_date"], []):
+
+    neos: List[dict] = []
+    for item in data.get("near_earth_objects", {}).get(date_str, []):
+        approach = item["close_approach_data"][0]
         neo = {
             "neo_id": item["id"],
             "name": item["name"],
             "close_approach_date": datetime.strptime(
-                item["close_approach_data"][0]["close_approach_date"], "%Y-%m-%d"
+                approach["close_approach_date"], "%Y-%m-%d"
             ).date(),
-            "diameter_km": item["estimated_diameter"]["kilometers"]["estimated_diameter_max"],
-            "velocity_km_s": float(item["close_approach_data"][0]["relative_velocity"]["kilometers_per_second"]),
-            "miss_distance_au": float(item["close_approach_data"][0]["miss_distance"]["astronomical"]),
+            "diameter_km": item["estimated_diameter"]["kilometers"][
+                "estimated_diameter_max"
+            ],
+            "velocity_km_s": float(
+                approach["relative_velocity"]["kilometers_per_second"]
+            ),
+            "miss_distance_au": float(approach["miss_distance"]["astronomical"]),
             "hazardous": item["is_potentially_hazardous_asteroid"],
         }
         neos.append(neo)
     return neos
 
-def store_neos(db: Session, neos):
-    stored = []
+def store_neos(db: Session, neos: List[dict]) -> List[models.Neo]:
+    """Insert new NEOs and notify subscribers about close approaches."""
+
+    stored: List[models.Neo] = []
     for data in neos:
         existing = db.query(models.Neo).filter_by(neo_id=data["neo_id"]).first()
         if existing:
@@ -47,12 +63,32 @@ def store_neos(db: Session, neos):
         obj = models.Neo(**data)
         db.add(obj)
         stored.append(obj)
+
     db.commit()
     for obj in stored:
+        db.refresh(obj)
+
+    subscribers = db.query(models.Subscriber).all()
+    for obj in stored:
         if obj.miss_distance_au < 0.05:
-            slack_session.post(
-                SLACK_WEBHOOK_URL,
-                json={"text": f"Close NEO: {obj.name} at {obj.miss_distance_au} AU"},
-                timeout=5,
-            )
+            payload = {
+                "neo_id": obj.neo_id,
+                "name": obj.name,
+                "close_approach_date": obj.close_approach_date,
+                "diameter_km": obj.diameter_km,
+                "velocity_km_s": obj.velocity_km_s,
+                "miss_distance_au": obj.miss_distance_au,
+                "hazardous": obj.hazardous,
+            }
+            for sub in subscribers:
+                delay = 1.0
+                for attempt in range(3):
+                    try:
+                        slack_session.post(sub.url, json=payload, timeout=5)
+                        break
+                    except Exception:
+                        if attempt == 2:
+                            break
+                        time.sleep(delay)
+                        delay *= 2
     return stored

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,58 +1,25 @@
-import pytest
+import os
 from datetime import datetime, date
+
 from app import services, models
 from app.database import SessionLocal, engine
 
 models.Base.metadata.create_all(bind=engine)
 
 
-def sample_neos():
-    return [
-        {
-            "neo_id": "10",
-            "name": "A",
-            "close_approach_date": date.today(),
-            "diameter_km": 1.0,
-            "velocity_km_s": 1.0,
-            "miss_distance_au": 0.04,
-            "hazardous": True,
-        }
-    ]
-
-
-def test_store_neos(monkeypatch):
-    models.Base.metadata.drop_all(bind=engine)
-    models.Base.metadata.create_all(bind=engine)
-    called = {}
-
-    def fake_post(url, json, timeout):
-        called["hit"] = True
-
-    monkeypatch.setattr(services.slack_session, "post", fake_post)
-
-    db = SessionLocal()
-    try:
-        stored = services.store_neos(db, sample_neos())
-        assert len(stored) == 1
-        assert called.get("hit")
-        again = services.store_neos(db, sample_neos())
-        assert len(again) == 0
-    finally:
-        db.close()
-
-
 def test_fetch_neos(monkeypatch):
+    today = datetime.utcnow().strftime("%Y-%m-%d")
     payload = {
         "near_earth_objects": {
-            datetime.utcnow().strftime("%Y-%m-%d"): [
+            today: [
                 {
-                    "id": "10",
-                    "name": "A",
+                    "id": "42",
+                    "name": "Apophis",
                     "close_approach_data": [
                         {
-                            "close_approach_date": date.today().strftime("%Y-%m-%d"),
+                            "close_approach_date": today,
                             "relative_velocity": {"kilometers_per_second": "1"},
-                            "miss_distance": {"astronomical": "0.1"},
+                            "miss_distance": {"astronomical": "0.04"},
                         }
                     ],
                     "estimated_diameter": {"kilometers": {"estimated_diameter_max": 1}},
@@ -70,8 +37,108 @@ def test_fetch_neos(monkeypatch):
             return payload
 
     def fake_get(url, params, timeout):
+        assert params["start_date"] == today
         return Resp()
 
-    monkeypatch.setattr(services.requests, "get", fake_get)
+    monkeypatch.setattr(services.httpx, "get", fake_get)
     result = services.fetch_neos(datetime.utcnow())
-    assert result[0]["neo_id"] == "10"
+    assert result == [
+        {
+            "neo_id": "42",
+            "name": "Apophis",
+            "close_approach_date": date.fromisoformat(today),
+            "diameter_km": 1,
+            "velocity_km_s": 1.0,
+            "miss_distance_au": 0.04,
+            "hazardous": False,
+        }
+    ]
+
+
+def test_store_neos(monkeypatch):
+    models.Base.metadata.drop_all(bind=engine)
+    models.Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        db.add(models.Subscriber(url="http://example.com"))
+        db.commit()
+    finally:
+        db.close()
+
+    sent = []
+    calls = {"n": 0}
+
+    def fake_post(url, json, timeout):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise Exception("boom")
+        sent.append(url)
+
+    monkeypatch.setattr(services.slack_session, "post", fake_post)
+
+    db = SessionLocal()
+    try:
+        neos = [
+            {
+                "neo_id": "1",
+                "name": "One",
+                "close_approach_date": date.today(),
+                "diameter_km": 1.0,
+                "velocity_km_s": 1.0,
+                "miss_distance_au": 0.04,
+                "hazardous": True,
+            },
+            {
+                "neo_id": "2",
+                "name": "Two",
+                "close_approach_date": date.today(),
+                "diameter_km": 1.0,
+                "velocity_km_s": 1.0,
+                "miss_distance_au": 0.5,
+                "hazardous": False,
+            },
+        ]
+        stored = services.store_neos(db, neos)
+        assert len(stored) == 2
+        assert sent == ["http://example.com"]
+        assert calls["n"] == 2
+
+        again = services.store_neos(db, neos)
+        assert len(again) == 0
+    finally:
+        db.close()
+
+def test_store_neos_retries(monkeypatch):
+    models.Base.metadata.drop_all(bind=engine)
+    models.Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        db.add(models.Subscriber(url="http://example.com"))
+        db.commit()
+    finally:
+        db.close()
+
+    calls = {"n": 0}
+    def always_fail(url, json, timeout):
+        calls["n"] += 1
+        raise Exception("boom")
+
+    monkeypatch.setattr(services.slack_session, "post", always_fail)
+
+    db = SessionLocal()
+    try:
+        neos = [
+            {
+                "neo_id": "x",
+                "name": "Fail",
+                "close_approach_date": date.today(),
+                "diameter_km": 1.0,
+                "velocity_km_s": 1.0,
+                "miss_distance_au": 0.04,
+                "hazardous": True,
+            }
+        ]
+        services.store_neos(db, neos)
+        assert calls["n"] == 3
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- implement `fetch_neos` using `httpx` and env key
- implement `store_neos` with upsert, subscriber alerts and retries
- add comprehensive unit tests for the service functions
- adjust ingest integration test for new behaviour

## Testing
- `pytest -q`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_b_68727a45188c832f939b7eac8dfabeef