### PR TITLE
Implement Chart.js dashboard and tests

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,78 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  async function loadInitial() {
+    try {
+      const res = await fetch('/neos');
+      if (!res.ok) throw new Error('bad');
+      return await res.json();
+    } catch (e) {
+      return [];
+    }
+  }
+
+  const data = await loadInitial();
+  const stats = {};
+  data.forEach(n => {
+    const d = n.close_approach_date;
+    if (!stats[d]) stats[d] = {count:0, min: Infinity};
+    stats[d].count += 1;
+    stats[d].min = Math.min(stats[d].min, n.miss_distance_au);
+  });
+
+  const labels = Object.keys(stats).sort();
+  const countData = labels.map(d => stats[d].count);
+  const minData = labels.map(d => stats[d].min);
+
+  const ctx = document.getElementById('neoChart').getContext('2d');
+  const neoChart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        { label: 'Count', data: countData, borderColor: 'blue', backgroundColor: 'rgba(0,0,255,0.2)', yAxisID: 'y' },
+        { label: 'Min Distance (AU)', data: minData, borderColor: 'red', backgroundColor: 'rgba(255,0,0,0.2)', yAxisID: 'y1' },
+      ]
+    },
+    options: {
+      interaction: { mode: 'index', intersect: false },
+      scales: {
+        y: { type: 'linear', position: 'left' },
+        y1: { type: 'linear', position: 'right', grid: { drawOnChartArea: false } }
+      }
+    }
+  });
+  window.neoChart = neoChart;
+
+  function update(neo) {
+    const d = neo.close_approach_date;
+    if (!stats[d]) {
+      stats[d] = {count:0, min: Infinity};
+    }
+    stats[d].count += 1;
+    stats[d].min = Math.min(stats[d].min, neo.miss_distance_au);
+    const lbls = Object.keys(stats).sort();
+    neoChart.data.labels = lbls;
+    neoChart.data.datasets[0].data = lbls.map(k => stats[k].count);
+    neoChart.data.datasets[1].data = lbls.map(k => stats[k].min);
+    neoChart.update();
+  }
+
+  const evtSource = new EventSource('/stream/neos');
+  evtSource.onmessage = e => {
+    try {
+      const neo = JSON.parse(e.data);
+      update(neo);
+    } catch {}
+  };
+
+  const form = document.getElementById('subForm');
+  if (form) {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const url = document.getElementById('subUrl').value;
+      try {
+        await fetch('/subscribe', { method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify({url})});
+      } catch {}
+      document.getElementById('subUrl').value = '';
+    });
+  }
+});

--- a/static/index.html
+++ b/static/index.html
@@ -2,35 +2,15 @@
 <html>
 <head>
 <title>NEO Watcher</title>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.css" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.2/d3.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
+<script src="../node_modules/chart.js/dist/chart.umd.js"></script>
 </head>
 <body>
 <h1>NEO Watcher Dashboard</h1>
-<canvas id="chart"></canvas>
+<canvas id="neoChart"></canvas>
 <form id="subForm">
   <input type="url" id="subUrl" placeholder="Webhook URL" required />
   <button type="submit">Subscribe</button>
 </form>
-<script>
-const evtSource = new EventSource('/stream/neos');
-const ctx = document.getElementById('chart').getContext('2d');
-const chart = new Chart(ctx, {type:'line', data:{labels:[], datasets:[{label:'NEOs', data:[]}]} });
-evtSource.onmessage = function(e){
-  const data = JSON.parse(e.data);
-  chart.data.labels.push(new Date().toISOString());
-  chart.data.datasets[0].data.push(data.length);
-  chart.update();
-  anime({targets:'h1', scale:[1,1.1], direction:'alternate', duration:500});
-};
-document.getElementById('subForm').addEventListener('submit', async (e)=>{
-  e.preventDefault();
-  const url = document.getElementById('subUrl').value;
-  await fetch('/subscribe', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({url})});
-  document.getElementById('subUrl').value='';
-});
-</script>
+<script defer src="app.js"></script>
 </body>
 </html>

--- a/tests/ui/test_chart.spec.js
+++ b/tests/ui/test_chart.spec.js
@@ -1,0 +1,61 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const sampleData = [
+  {
+    id: 1,
+    neo_id: '1',
+    name: 'Test1',
+    close_approach_date: '2020-01-01',
+    diameter_km: 1,
+    velocity_km_s: 1,
+    miss_distance_au: 0.5,
+    hazardous: false
+  }
+];
+
+test('chart renders and updates', async ({ page }) => {
+  const filePath = path.resolve(__dirname, '../../static/index.html');
+
+  await page.route('**/neos', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(sampleData)
+    });
+  });
+
+  await page.addInitScript(() => {
+    class FakeEventSource {
+      constructor(url) { FakeEventSource.instance = this; this.url = url; }
+      close() {}
+    }
+    window.EventSource = FakeEventSource;
+  });
+
+  await page.goto('file://' + filePath);
+
+  await expect(page.locator('#neoChart')).toBeVisible();
+
+  await page.waitForFunction(() => window.neoChart && window.neoChart.data.datasets.length > 1);
+
+  const labels = await page.evaluate(() => window.neoChart.data.datasets.map(d => d.label));
+  expect(labels).toContain('Count');
+  expect(labels).toContain('Min Distance (AU)');
+
+  await page.evaluate(() => {
+    const neo = {
+      id: 2,
+      neo_id: '2',
+      name: 'Test2',
+      close_approach_date: '2020-01-02',
+      diameter_km: 1,
+      velocity_km_s: 1,
+      miss_distance_au: 0.4,
+      hazardous: false
+    };
+    window.EventSource.instance.onmessage({ data: JSON.stringify(neo) });
+  });
+
+  await page.waitForFunction(() => window.neoChart.data.labels.includes('2020-01-02'));
+});


### PR DESCRIPTION
## Summary
- create dedicated `neoChart` canvas and load Chart.js locally
- add `app.js` to fetch NEO data, build the chart and update via SSE
- add Playwright test verifying chart initialization and live update

## Testing
- `npx playwright install --with-deps`
- `npx playwright test tests/ui/test_chart.spec.js`

------
https://chatgpt.com/codex/tasks/task_b_687280807a0c832f94e2b48780d84e88