### PR TITLE
Add Playwright setup and UI test script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,3 +10,5 @@ jobs:
           python-version: '3.9'
       - run: pip install -r requirements.txt
       - run: pytest
+      - name: Run UI tests
+        run: npm run test:ui

--- a/README.md
+++ b/README.md
@@ -16,3 +16,12 @@ docker-compose up --build --detach
 pip install -r requirements.txt
 pytest
 ```
+
+## UI Tests
+
+```bash
+npm install
+npm run test:ui
+```
+
+The `postinstall` step will download the necessary Playwright browsers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,16 @@
     "": {
       "name": "near-earth-object-watcher",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "animejs": "^4.0.2",
         "chart.js": "^4.5.0",
         "d3": "^7.9.0"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.54.1",
+        "playwright": "^1.54.1"
       }
     },
     "node_modules/@kurkle/color": {
@@ -19,6 +24,22 @@
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.1.tgz",
+      "integrity": "sha512-FS8hQ12acieG2dYSksmLOF7BNxnVf2afRJdCuM1eMSxj6QTSE6G4InGF7oApGgDb65MX7AwMVlIkpru0yZA4Xw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/animejs": {
       "version": "4.0.2",
@@ -457,6 +478,21 @@
         "robust-predicates": "^3.0.2"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -476,6 +512,38 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
+      "integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.1.tgz",
+      "integrity": "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/robust-predicates": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "npx playwright install --with-deps",
+    "test:ui": "npm ci && npm run postinstall && npx playwright test tests/ui"
   },
   "keywords": [],
   "author": "",
@@ -17,5 +19,9 @@
     "animejs": "^4.0.2",
     "chart.js": "^4.5.0",
     "d3": "^7.9.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.54.1",
+    "playwright": "^1.54.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,6 +1,5 @@
+// playwright.config.js
 module.exports = {
   testDir: './tests/ui',
-  use: {
-    headless: true,
-  },
+  use: { headless: true, actionTimeout: 0, navigationTimeout: 30000 },
 };

--- a/tests/ui/test_d3.spec.js
+++ b/tests/ui/test_d3.spec.js
@@ -8,6 +8,16 @@ test('danger map renders and updates', async ({ page }) => {
     { id: 1, neo_id: '1', name: 'Now', close_approach_date: today, diameter_km: 1.5, velocity_km_s: 1, miss_distance_au: 0.01, hazardous: true }
   ];
 
+  await page.addInitScript(sample => {
+    const origFetch = window.fetch;
+    window.fetch = (url, opts) => {
+      if (typeof url === 'string' && url.includes('/neos')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(sample) });
+      }
+      return origFetch(url, opts);
+    };
+  }, sampleToday);
+
   await page.route('**/neos?*', route => {
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(sampleToday) });
   });


### PR DESCRIPTION
## Summary
- install Playwright and configure postinstall to fetch browsers
- add test:ui npm script
- define Playwright test config
- document UI tests in README
- run UI tests in CI
- adjust `test_d3` spec to work when loading page via `file:` URL

## Testing
- `npm ci`
- `npx playwright install --with-deps`
- `npx playwright test tests/ui`


------
https://chatgpt.com/codex/tasks/task_b_6872880adbec832f9c1e21175f00cbdd