### PR TITLE
Add coverage threshold in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Type-check with mypy
         run: mypy app
       - name: Run tests with coverage
-        run: pytest --cov
+        run: pytest --cov --cov-fail-under=100
       - name: Install Node dependencies
         run: npm ci
       - name: Run UI tests


### PR DESCRIPTION
## Summary
- update CI workflow to enforce 100% coverage

## Testing
- `flake8` *(fails: E302, E501 etc.)*
- `black --check .` *(fails: would reformat files)*
- `mypy app` *(fails: missing stubs)*
- `pytest --cov --cov-fail-under=100`
- `npx playwright install --with-deps` *(failed: npm deps not installed)*
- `npx playwright test` *(interrupted)*
- `docker build . -t neo-watcher:latest --no-cache` *(failed: Docker daemon not running)*
- `terraform init`
- `terraform validate`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_68729c9392e4832fb698a6399636d24e